### PR TITLE
CommonPageTemplate の PropsType追加

### DIFF
--- a/src/components/CommonPageTemplate/index.tsx
+++ b/src/components/CommonPageTemplate/index.tsx
@@ -13,7 +13,11 @@ const StyledBox = styled(Box)(() => ({
   paddingTop: '60px',
 }));
 
-const CommonPageTemplate: React.FC = ({ children }) => (
+type CommonPageTemplateProps = {
+  children: React.ReactNode,
+}
+
+const CommonPageTemplate: React.FC<CommonPageTemplateProps> = ({ children }: CommonPageTemplateProps) => (
   <StyledContainer>
     <Header title="This is Next.js Template" />
     <StyledBox m={0}>


### PR DESCRIPTION
React v18のType更新に伴ってchildrenの扱い方が変わったため、React.ReactNodeのPropsを追加