### PR TITLE
fix: update jest transform config to support ESM modules (uuid v13)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   ],
   transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(ts|tsx)$'],
   transform: {
-    '^.+\\.(ts|tsx)$': '@swc/jest',
+    '^.+\\.(t|j)sx?$': '@swc/jest',
   },
   watchPlugins: [
     'jest-watch-typeahead/filename',


### PR DESCRIPTION
## 概要
`uuid` v13 へのアップデートによる CI エラーを修正しました。

## 原因
`uuid` v13 から ESM (`export` 構文) が導入されましたが、Jest の設定で [.js](cci:7://file:///workspaces/nextjs-template/jest.config.js:0:0-0:0) ファイルがトランスパイルされていなかったため、構文エラーが発生していました。

## 変更点
- [jest.config.js](cci:7://file:///workspaces/nextjs-template/jest.config.js:0:0-0:0) の `transform` 設定を更新し、[.js](cci:7://file:///workspaces/nextjs-template/jest.config.js:0:0-0:0) / `.jsx` ファイルも `@swc/jest` で処理されるようにしました。

## 検証
- ローカルで `npm test` が通ることを確認しました。