### PR TITLE
chore: update Node.js version to 24.x (current LTS)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
## 概要
GitHub ActionsのNode.jsバージョンを22.xから24.x（現在のLTS）に更新しました。

## 変更内容
- のジョブとジョブのNode.jsバージョンを24.xに更新
- は既に24を使用していたため変更なし

## 理由
Node.js 24が現在のLTSバージョンであるため、最新の安定版を使用することでセキュリティとパフォーマンスの向上が期待できます。