### PR TITLE
Update Devcontainer Node Versino to 24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:4-22-bookworm"
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:24"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},


### PR DESCRIPTION
DevcontainerのNode.jsのバージョンをLTSである24に変更しました。

ref : https://hub.docker.com/r/microsoft/devcontainers-typescript-node