### PR TITLE
Update Storybook to 10.x

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test-all": "npm run lint && npm run type-check && npm run test",
     "e2e-test": "playwright test",
     "prepare": "husky",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build"
   },
   "husky": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
Storybook 10.x へアップグレードするにあたり、実行時のエラーに対処しました。

- tsconfig.jsonの`moduleResolution`オプションを`bundler`に変更しました
- DevContainer内でStorybookがブラウザを開けないため、`--no-open`オプションを追加しました。