### PR TITLE
Add minimumReleaseAge settings in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:base"],
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
npm で公開されたアップデートの即反映を避けるために、minimumReleaseAgeを設定しました。